### PR TITLE
give `/talk` non-subscribers options to create the call anyway and to login

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -77,14 +77,6 @@ const main = async () => {
   const browser = await calcBrowserCapabilities();
   const joinRoom = checkJoinRoom(extractRoomNameFromUrl(), browser);
 
-  /** WHAT'S THE LOGIC I WANT HERE?
-   *
-   * if create=y is set, then try to join the room but also display the UI
-   * So maybe just display the UI immediately?
-   *
-   * Nah, would be better to show once we've failed to join for the first time.
-   *
-   */
   if (!joinRoom || joinRoom === "widget") {
     const context: Context = {
       browser,

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,6 +77,14 @@ const main = async () => {
   const browser = await calcBrowserCapabilities();
   const joinRoom = checkJoinRoom(extractRoomNameFromUrl(), browser);
 
+  /** WHAT'S THE LOGIC I WANT HERE?
+   *
+   * if create=y is set, then try to join the room but also display the UI
+   * So maybe just display the UI immediately?
+   *
+   * Nah, would be better to show once we've failed to join for the first time.
+   *
+   */
   if (!joinRoom || joinRoom === "widget") {
     const context: Context = {
       browser,
@@ -282,7 +290,10 @@ const renderHomePage = (options: WelcomeScreenOptions) => {
           reportAction("braveRequestAdsEnabled", { result });
           if (result) {
             // good to start the call now
-            joinConferenceRoom(generateRoomName(), true);
+            joinConferenceRoom(
+              options.roomNameOverride ?? generateRoomName(),
+              true
+            );
             return;
           }
 
@@ -298,7 +309,10 @@ const renderHomePage = (options: WelcomeScreenOptions) => {
           window.location.reload();
         };
       } else {
-        joinConferenceRoom(generateRoomName(), true);
+        joinConferenceRoom(
+          options.roomNameOverride ?? generateRoomName(),
+          true
+        );
       }
     };
   }
@@ -547,6 +561,11 @@ const joinConferenceRoom = async (
         const isSubscribed = await userIsSubscribed();
         if (!isSubscribed) {
           notice("Waiting for a subscriber to create the room...");
+          renderHomePage({
+            showSubscribeCTA: true,
+            showStartCall: true,
+            roomNameOverride: roomName,
+          });
           setTimeout(() => joinConferenceRoom(roomName, false), 5_000);
           return;
         }

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -31,6 +31,11 @@ export interface WelcomeScreenOptions {
   // it asks for the user to opt in - either by manual instruction UI
   // or by calling braveRequestAdsEnabled if available
   startCallButtonPromptsOptIn?: boolean;
+
+  // in some cases, we know the name room we'd want to join/create,
+  // (e.g. when `create=y` is present), so allow override
+  // of the auto-generated room name
+  roomNameOverride?: string;
 }
 
 export function checkJoinRoom(


### PR DESCRIPTION
This is not totally ideal as when you login, it loses the room name you were trying to connect to, so you need to go back to slack and click the link again :(  But it's better than getting stuck, and at least you can start a 1:1 room.

Re #16


https://user-images.githubusercontent.com/51444/144041013-9fb5c5cf-2e5a-4cea-ad91-1602579705d9.mov

