### PR TITLE
Fetch credentials if order exists but has no credentials

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,9 @@ const main = async () => {
         await s.recoverCredsIfRequired(orderId);
       }
       autoJoinRoom = getAutoOpenRoom();
-    } catch (e) {}
+    } catch (e) {
+      console.error("Failed to update order", e);
+    }
   }
 
   // fast track check for whether we should immediately try to join a room

--- a/src/subscriptions.ts
+++ b/src/subscriptions.ts
@@ -44,12 +44,12 @@ export async function recoverCredsIfRequired(orderId: string): Promise<void> {
     currentMethod = "refresh_order";
     log("calling refresh_order...");
     const order = await sdk.refresh_order(orderId);
+    log("order status is ", order.status);
 
-    currentMethod = "credential_summary";
-    log("calling credential_summary...");
-    const summary = await sdk.credential_summary(order.location);
     if (["paid", "canceled"].includes(order.status)) {
-      if (!summary) {
+      // user should have a subscription, re-fetch their credentials if not
+      const isSubscribed = await checkSubscribedUsingSDK();
+      if (!isSubscribed) {
         currentMethod = "fetch_order_credentials";
         log("calling fetch_order_credentials...");
         await sdk.fetch_order_credentials(orderId);


### PR DESCRIPTION
This logic was there previously, but failed because it didn't take into account the changed contract for `credential_summary` in the new sdk (where it now returns a value with `active` set to false in this case) . Removed the duplication of this check so it should not happen again.

Net effect was that new logins did not work as the credentials were not fetched, see [slack](https://bravesoftware.slack.com/archives/C021S0FN3V1/p1638739925331200).