### PR TITLE
Support `create_only=y` parameter

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,14 +23,6 @@ const isProduction: boolean = process.env.ENVIRONMENT === "production";
 
 const params = new URLSearchParams(window.location.search);
 
-window.addEventListener(
-  "message",
-  (event) => {
-    console.log("got message!", event);
-  },
-  false
-);
-
 // there's a chance that window.onload has already fired by the time this code runs
 if (document.readyState === "complete") {
   window.setTimeout(() => main());

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,14 @@ const isProduction: boolean = process.env.ENVIRONMENT === "production";
 
 const params = new URLSearchParams(window.location.search);
 
+window.addEventListener(
+  "message",
+  (event) => {
+    console.log("got message!", event);
+  },
+  false
+);
+
 // there's a chance that window.onload has already fired by the time this code runs
 if (document.readyState === "complete") {
   window.setTimeout(() => main());
@@ -82,6 +90,12 @@ const main = async () => {
     browser
   );
 
+  if (joinRoom && params.get("create_only") === "y") {
+    hideLoadingIndicators();
+    await immediatelyCreateRoom(joinRoom);
+    return;
+  }
+
   if (!joinRoom || joinRoom === "widget") {
     const context: Context = {
       browser,
@@ -102,6 +116,16 @@ const main = async () => {
     joinRoom !== "widget" ? joinRoom : generateRoomName(),
     false
   );
+};
+
+const immediatelyCreateRoom = async (roomName: string) => {
+  try {
+    await fetchJWT(roomName, true, notice);
+    window.close();
+  } catch (error: any) {
+    console.error(error);
+    notice(error.message);
+  }
 };
 
 const checkDevOverride = (code: string): boolean | null => {


### PR DESCRIPTION
To create a room then close the window, used by the gcal plugin.

TODO: display better messaging if they are  not a subscriber, rather than just creating a 1:1 room.