### PR TITLE
Refresh tokens disappearing

### DIFF
--- a/src/jwt-store.test.ts
+++ b/src/jwt-store.test.ts
@@ -1,4 +1,5 @@
 import { loadLocalJwtStore } from "./jwt-store";
+import "./js/jwt-decode";
 
 afterAll(() => {
   // set the system time back to normal
@@ -34,4 +35,82 @@ test("mau calculation behaves as we expect", () => {
   jest.setSystemTime(new Date("2011-04-01T13:24:00Z"));
   expect(s.isNewMonthlyActiveUser()).toBe(true);
   expect(s.isNewMonthlyActiveUser()).toBe(false);
+});
+
+function createDummyJWTWithExpiry(name: string, exp: Date): string {
+  // we only need to create enough of a jwt to exercise our expiry time checking -
+  // this is clearly not a fully valid jwt!
+  const dummyJwtValue = {
+    exp: Math.floor(exp.valueOf() / 1000),
+  };
+
+  return `header.${btoa(JSON.stringify(dummyJwtValue))}.(${name})`;
+}
+
+test.only("jwt expiry works as expected", () => {
+  jest.useFakeTimers();
+
+  jest.setSystemTime(new Date("2021-04-01T00:00:00Z"));
+  const s = loadLocalJwtStore(true);
+
+  const nonExpiredJwt = createDummyJWTWithExpiry(
+    "nonExpiredJwt",
+    new Date("2021-04-01T03:00:00Z")
+  );
+
+  const nonExpiredRefresh = createDummyJWTWithExpiry(
+    "nonExpiredRefresh",
+    new Date("2021-04-02T00:00:00Z")
+  );
+
+  const expiredJwt = createDummyJWTWithExpiry(
+    "expiredJwt",
+    new Date("2021-03-01T00:00:00Z")
+  );
+
+  const expiredRefresh = createDummyJWTWithExpiry(
+    "expiredRefresh",
+    new Date("2021-03-02T00:00:00Z")
+  );
+
+  s.storeJwtForRoom("ok", nonExpiredJwt, nonExpiredRefresh);
+  s.storeJwtForRoom("expired", expiredJwt, expiredRefresh);
+  s.storeJwtForRoom("okNoRefresh", nonExpiredJwt);
+
+  // check that local storage has now been updated - no expiry checking is done on write
+  const confabs = JSON.parse(window.localStorage.getItem("confabs")!);
+  expect(confabs.JWTs).toEqual({
+    ok: nonExpiredJwt,
+    expired: expiredJwt,
+    okNoRefresh: nonExpiredJwt,
+  });
+  expect(confabs.refresh).toEqual({
+    ok: nonExpiredRefresh,
+    expired: expiredRefresh,
+  });
+
+  // now reload:
+  //  this should remove the expired entries, both in memory and in local storage
+  const reloaded = loadLocalJwtStore(true);
+  expect(reloaded.findJwtForRoom("ok")).toBe(nonExpiredJwt);
+  expect(reloaded.findJwtForRoom("expired")).toBeUndefined();
+  expect(reloaded.findJwtForRoom("okNoRefresh")).toBe(nonExpiredJwt);
+
+  expect(reloaded.findRefreshTokenForRoom("ok")).toBe(nonExpiredRefresh);
+  // temporarily: the expired refresh token should not be removed
+  expect(reloaded.findRefreshTokenForRoom("expired")).toBe(expiredRefresh);
+  expect(reloaded.findRefreshTokenForRoom("okNoRefresh")).toBeUndefined();
+  const confabs2 = JSON.parse(window.localStorage.getItem("confabs")!);
+
+  // expired entries should be removed from jwts
+  expect(confabs2.JWTs).toEqual({
+    ok: nonExpiredJwt,
+    okNoRefresh: nonExpiredJwt,
+  });
+
+  // temporarily, the expired refresh token should remain
+  expect(confabs2.refresh).toEqual({
+    ok: nonExpiredRefresh,
+    expired: expiredRefresh,
+  });
 });

--- a/src/rooms.ts
+++ b/src/rooms.ts
@@ -172,6 +172,7 @@ export const fetchJWT = async (
 
   const refreshToken = store.findRefreshTokenForRoom(roomName);
   if (refreshToken) {
+    reportProgress("Checking moderator status...");
     console.log("attempting refresh: ", refreshToken);
     const response = await attemptTokenRefresh(roomName, refreshToken);
     if (response) {


### PR DESCRIPTION
Don't think this is a fix, but should aid diagnosis:
- treat the in-memory copy of "confabs" as the master after initial load
- don't expire refresh tokens for now
- add a unit test
Re #81