### PR TITLE
Remove the manually maintained version number

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ if (document.readyState === "complete") {
 const main = async () => {
   // these envvars are set by the EnvironmentPlugin in webpack.config.js
   console.log(
-    `!!! version 0.11.58 (${process.env.GIT_VERSION} ${process.env.ENVIRONMENT})`
+    `!!! version ${process.env.GIT_VERSION} (${process.env.ENVIRONMENT})`
   );
 
   if (useBraveRequestAdsEnabledApi) {


### PR DESCRIPTION
The git commit precisely identifies what version of code is deployed, and with multple branches the manual version number is non-sequential and genrates branch merge confusion.