### PR TITLE
Update node forge

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,10 +13,10 @@
       },
       "devDependencies": {
         "@brave-intl/skus-sdk": "^0.1.0",
-        "@types/jest": "27.0.3",
+        "@types/jest": "27.4.0",
         "@types/react": "^17.0.38",
         "@types/react-dom": "^17.0.11",
-        "autoprefixer": "10.4.1",
+        "autoprefixer": "10.4.2",
         "copy-webpack-plugin": "10.2.0",
         "css-loader": "6.5.1",
         "css-minimizer-webpack-plugin": "^3.3.1",
@@ -1118,9 +1118,9 @@
       }
     },
     "node_modules/@types/jest": {
-      "version": "27.0.3",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.0.3.tgz",
-      "integrity": "sha512-cmmwv9t7gBYt7hNKH5Spu7Kuu/DotGa+Ff+JGRKZ4db5eh8PnKS4LuebJ3YLUoyOyIHraTGyULn23YtEAm0VSg==",
+      "version": "27.4.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.4.0.tgz",
+      "integrity": "sha512-gHl8XuC1RZ8H2j5sHv/JqsaxXkDDM9iDOgu0Wp8sjs4u/snb2PVehyWXJPr+ORA0RPpgw231mnutWI1+0hgjIQ==",
       "dev": true,
       "dependencies": {
         "jest-diff": "^27.0.0",
@@ -1743,13 +1743,13 @@
       "dev": true
     },
     "node_modules/autoprefixer": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.1.tgz",
-      "integrity": "sha512-B3ZEG7wtzXDRCEFsan7HmR2AeNsxdJB0+sEC0Hc5/c2NbhJqPwuZm+tn233GBVw82L+6CtD6IPSfVruwKjfV3A==",
+      "version": "10.4.2",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.2.tgz",
+      "integrity": "sha512-9fOPpHKuDW1w/0EKfRmVnxTDt8166MAnLI3mgZ1JCnhNtYWxcJ6Ud5CO/AVOZi/AvFa8DY9RTy3h3+tFBlrrdQ==",
       "dev": true,
       "dependencies": {
         "browserslist": "^4.19.1",
-        "caniuse-lite": "^1.0.30001294",
+        "caniuse-lite": "^1.0.30001297",
         "fraction.js": "^4.1.2",
         "normalize-range": "^0.1.2",
         "picocolors": "^1.0.0",
@@ -10149,9 +10149,9 @@
       }
     },
     "@types/jest": {
-      "version": "27.0.3",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.0.3.tgz",
-      "integrity": "sha512-cmmwv9t7gBYt7hNKH5Spu7Kuu/DotGa+Ff+JGRKZ4db5eh8PnKS4LuebJ3YLUoyOyIHraTGyULn23YtEAm0VSg==",
+      "version": "27.4.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.4.0.tgz",
+      "integrity": "sha512-gHl8XuC1RZ8H2j5sHv/JqsaxXkDDM9iDOgu0Wp8sjs4u/snb2PVehyWXJPr+ORA0RPpgw231mnutWI1+0hgjIQ==",
       "dev": true,
       "requires": {
         "jest-diff": "^27.0.0",
@@ -10697,13 +10697,13 @@
       "dev": true
     },
     "autoprefixer": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.1.tgz",
-      "integrity": "sha512-B3ZEG7wtzXDRCEFsan7HmR2AeNsxdJB0+sEC0Hc5/c2NbhJqPwuZm+tn233GBVw82L+6CtD6IPSfVruwKjfV3A==",
+      "version": "10.4.2",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.2.tgz",
+      "integrity": "sha512-9fOPpHKuDW1w/0EKfRmVnxTDt8166MAnLI3mgZ1JCnhNtYWxcJ6Ud5CO/AVOZi/AvFa8DY9RTy3h3+tFBlrrdQ==",
       "dev": true,
       "requires": {
         "browserslist": "^4.19.1",
-        "caniuse-lite": "^1.0.30001294",
+        "caniuse-lite": "^1.0.30001297",
         "fraction.js": "^4.1.2",
         "normalize-range": "^0.1.2",
         "picocolors": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@types/jest": "27.0.3",
         "@types/react": "^17.0.38",
         "@types/react-dom": "^17.0.11",
-        "autoprefixer": "10.4.0",
+        "autoprefixer": "10.4.1",
         "copy-webpack-plugin": "10.2.0",
         "css-loader": "6.5.1",
         "css-minimizer-webpack-plugin": "^3.3.1",
@@ -24,6 +24,7 @@
         "husky": "7.0.4",
         "jest": "27.4.7",
         "mini-css-extract-plugin": "2.4.5",
+        "node-forge": ">=1.0.0",
         "postcss": "8.4.5",
         "postcss-loader": "6.2.1",
         "postcss-nesting": "10.1.1",
@@ -1742,17 +1743,17 @@
       "dev": true
     },
     "node_modules/autoprefixer": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.0.tgz",
-      "integrity": "sha512-7FdJ1ONtwzV1G43GDD0kpVMn/qbiNqyOPMFTX5nRffI+7vgWoFEc6DcXOxHJxrWNDXrZh18eDsZjvZGUljSRGA==",
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.1.tgz",
+      "integrity": "sha512-B3ZEG7wtzXDRCEFsan7HmR2AeNsxdJB0+sEC0Hc5/c2NbhJqPwuZm+tn233GBVw82L+6CtD6IPSfVruwKjfV3A==",
       "dev": true,
       "dependencies": {
-        "browserslist": "^4.17.5",
-        "caniuse-lite": "^1.0.30001272",
-        "fraction.js": "^4.1.1",
+        "browserslist": "^4.19.1",
+        "caniuse-lite": "^1.0.30001294",
+        "fraction.js": "^4.1.2",
         "normalize-range": "^0.1.2",
         "picocolors": "^1.0.0",
-        "postcss-value-parser": "^4.1.0"
+        "postcss-value-parser": "^4.2.0"
       },
       "bin": {
         "autoprefixer": "bin/autoprefixer"
@@ -1984,13 +1985,13 @@
       "dev": true
     },
     "node_modules/browserslist": {
-      "version": "4.17.6",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.6.tgz",
-      "integrity": "sha512-uPgz3vyRTlEiCv4ee9KlsKgo2V6qPk7Jsn0KAn2OBqbqKo3iNcPEC1Ti6J4dwnz+aIRfEEEuOzC9IBk8tXUomw==",
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.19.1.tgz",
+      "integrity": "sha512-u2tbbG5PdKRTUoctO3NBD8FQ5HdPh1ZXPHzp1rwaa5jTc+RV9/+RlWiAIKmjRPQF+xbGM9Kklj5bZQFa2s/38A==",
       "dev": true,
       "dependencies": {
-        "caniuse-lite": "^1.0.30001274",
-        "electron-to-chromium": "^1.3.886",
+        "caniuse-lite": "^1.0.30001286",
+        "electron-to-chromium": "^1.4.17",
         "escalade": "^3.1.1",
         "node-releases": "^2.0.1",
         "picocolors": "^1.0.0"
@@ -2108,9 +2109,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001276",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001276.tgz",
-      "integrity": "sha512-psUNoaG1ilknZPxi8HuhQWobuhLqtYSRUxplfVkEJdgZNB9TETVYGSBtv4YyfAdGvE6gn2eb0ztiXqHoWJcGnw==",
+      "version": "1.0.30001298",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001298.tgz",
+      "integrity": "sha512-AcKqikjMLlvghZL/vfTHorlQsLDhGRalYf1+GmWCf5SCMziSGjRYQW/JEksj14NaYHIR6KIhrFAy0HV5C25UzQ==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -3299,9 +3300,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.3.888",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.888.tgz",
-      "integrity": "sha512-5iD1zgyPpFER4kJ716VsA4MxQ6x405dxdFNCEK2mITL075VHO5ResjY0xzQUZguCww/KlBxCA6JmBA9sDt1PRw==",
+      "version": "1.4.39",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.39.tgz",
+      "integrity": "sha512-bFH3gdRq/l7WlzSleiO6dwpZH3RhiJ8vlMq0tOJMfT+5nb+x397eJn2RHF6Ho/9GCKv+BkimNlUMHl9+Yh+Qcg==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -3829,9 +3830,9 @@
       }
     },
     "node_modules/fraction.js": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.1.1.tgz",
-      "integrity": "sha512-MHOhvvxHTfRFpF1geTK9czMIZ6xclsEor2wkIGYYq+PxcQqT7vStJqjhe6S1TenZrMZzo+wlqOufBDVepUEgPg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.1.2.tgz",
+      "integrity": "sha512-o2RiJQ6DZaR/5+Si0qJUIy637QMRudSi9kU/FFzx9EZazrIdnBgpU+3sEWCxAVhH2RtxW2Oz+T4p2o8uOPVcgA==",
       "dev": true,
       "engines": {
         "node": "*"
@@ -5974,12 +5975,12 @@
       "dev": true
     },
     "node_modules/node-forge": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.2.0.tgz",
+      "integrity": "sha512-M4AsdaP0bGNaSPtatd/+f76asocI0cFaURRdeQVZvrJBrYp2Qohv5hDbGHykuNqCb1BYjWHjdS6HlN50qbztwA==",
       "dev": true,
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">= 6.13.0"
       }
     },
     "node_modules/node-int64": {
@@ -6994,9 +6995,9 @@
       }
     },
     "node_modules/postcss-value-parser": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
-      "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
     },
     "node_modules/prelude-ls": {
@@ -7620,12 +7621,12 @@
       "dev": true
     },
     "node_modules/selfsigned": {
-      "version": "1.10.11",
-      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.11.tgz",
-      "integrity": "sha512-aVmbPOfViZqOZPgRBT0+3u4yZFHpmnIghLMlAcb5/xhp5ZtB/RVnKhz5vl2M32CLXAqR4kha9zfhNg0Lf/sxKA==",
+      "version": "1.10.13",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.13.tgz",
+      "integrity": "sha512-UmLwTKZwNmXYDAlRFhaEdgEg0dp9k5gfJXuO7uKvSqioN1M0+Mgf4V39IlVZMSuqGoCi6h5legkhNXvWy0rFSg==",
       "dev": true,
       "dependencies": {
-        "node-forge": "^0.10.0"
+        "node-forge": "^1.2.0"
       }
     },
     "node_modules/semver": {
@@ -10696,17 +10697,17 @@
       "dev": true
     },
     "autoprefixer": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.0.tgz",
-      "integrity": "sha512-7FdJ1ONtwzV1G43GDD0kpVMn/qbiNqyOPMFTX5nRffI+7vgWoFEc6DcXOxHJxrWNDXrZh18eDsZjvZGUljSRGA==",
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.1.tgz",
+      "integrity": "sha512-B3ZEG7wtzXDRCEFsan7HmR2AeNsxdJB0+sEC0Hc5/c2NbhJqPwuZm+tn233GBVw82L+6CtD6IPSfVruwKjfV3A==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.17.5",
-        "caniuse-lite": "^1.0.30001272",
-        "fraction.js": "^4.1.1",
+        "browserslist": "^4.19.1",
+        "caniuse-lite": "^1.0.30001294",
+        "fraction.js": "^4.1.2",
         "normalize-range": "^0.1.2",
         "picocolors": "^1.0.0",
-        "postcss-value-parser": "^4.1.0"
+        "postcss-value-parser": "^4.2.0"
       }
     },
     "babel-jest": {
@@ -10891,13 +10892,13 @@
       "dev": true
     },
     "browserslist": {
-      "version": "4.17.6",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.6.tgz",
-      "integrity": "sha512-uPgz3vyRTlEiCv4ee9KlsKgo2V6qPk7Jsn0KAn2OBqbqKo3iNcPEC1Ti6J4dwnz+aIRfEEEuOzC9IBk8tXUomw==",
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.19.1.tgz",
+      "integrity": "sha512-u2tbbG5PdKRTUoctO3NBD8FQ5HdPh1ZXPHzp1rwaa5jTc+RV9/+RlWiAIKmjRPQF+xbGM9Kklj5bZQFa2s/38A==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001274",
-        "electron-to-chromium": "^1.3.886",
+        "caniuse-lite": "^1.0.30001286",
+        "electron-to-chromium": "^1.4.17",
         "escalade": "^3.1.1",
         "node-releases": "^2.0.1",
         "picocolors": "^1.0.0"
@@ -10992,9 +10993,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001276",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001276.tgz",
-      "integrity": "sha512-psUNoaG1ilknZPxi8HuhQWobuhLqtYSRUxplfVkEJdgZNB9TETVYGSBtv4YyfAdGvE6gn2eb0ztiXqHoWJcGnw==",
+      "version": "1.0.30001298",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001298.tgz",
+      "integrity": "sha512-AcKqikjMLlvghZL/vfTHorlQsLDhGRalYf1+GmWCf5SCMziSGjRYQW/JEksj14NaYHIR6KIhrFAy0HV5C25UzQ==",
       "dev": true
     },
     "chalk": {
@@ -11906,9 +11907,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.888",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.888.tgz",
-      "integrity": "sha512-5iD1zgyPpFER4kJ716VsA4MxQ6x405dxdFNCEK2mITL075VHO5ResjY0xzQUZguCww/KlBxCA6JmBA9sDt1PRw==",
+      "version": "1.4.39",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.39.tgz",
+      "integrity": "sha512-bFH3gdRq/l7WlzSleiO6dwpZH3RhiJ8vlMq0tOJMfT+5nb+x397eJn2RHF6Ho/9GCKv+BkimNlUMHl9+Yh+Qcg==",
       "dev": true
     },
     "emittery": {
@@ -12324,9 +12325,9 @@
       "dev": true
     },
     "fraction.js": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.1.1.tgz",
-      "integrity": "sha512-MHOhvvxHTfRFpF1geTK9czMIZ6xclsEor2wkIGYYq+PxcQqT7vStJqjhe6S1TenZrMZzo+wlqOufBDVepUEgPg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.1.2.tgz",
+      "integrity": "sha512-o2RiJQ6DZaR/5+Si0qJUIy637QMRudSi9kU/FFzx9EZazrIdnBgpU+3sEWCxAVhH2RtxW2Oz+T4p2o8uOPVcgA==",
       "dev": true
     },
     "fresh": {
@@ -13954,9 +13955,9 @@
       }
     },
     "node-forge": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.2.0.tgz",
+      "integrity": "sha512-M4AsdaP0bGNaSPtatd/+f76asocI0cFaURRdeQVZvrJBrYp2Qohv5hDbGHykuNqCb1BYjWHjdS6HlN50qbztwA==",
       "dev": true
     },
     "node-int64": {
@@ -14657,9 +14658,9 @@
       }
     },
     "postcss-value-parser": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
-      "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
     },
     "prelude-ls": {
@@ -15123,12 +15124,12 @@
       "dev": true
     },
     "selfsigned": {
-      "version": "1.10.11",
-      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.11.tgz",
-      "integrity": "sha512-aVmbPOfViZqOZPgRBT0+3u4yZFHpmnIghLMlAcb5/xhp5ZtB/RVnKhz5vl2M32CLXAqR4kha9zfhNg0Lf/sxKA==",
+      "version": "1.10.13",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.13.tgz",
+      "integrity": "sha512-UmLwTKZwNmXYDAlRFhaEdgEg0dp9k5gfJXuO7uKvSqioN1M0+Mgf4V39IlVZMSuqGoCi6h5legkhNXvWy0rFSg==",
       "dev": true,
       "requires": {
-        "node-forge": "^0.10.0"
+        "node-forge": "^1.2.0"
       }
     },
     "semver": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "husky": "7.0.4",
     "jest": "27.4.7",
     "mini-css-extract-plugin": "2.4.5",
+    "node-forge": ">=1.0.0",
     "postcss": "8.4.5",
     "postcss-loader": "6.2.1",
     "postcss-nesting": "10.1.1",

--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
   "homepage": "https://github.com/brave/brave-talk#readme",
   "devDependencies": {
     "@brave-intl/skus-sdk": "^0.1.0",
-    "@types/jest": "27.0.3",
+    "@types/jest": "27.4.0",
     "@types/react": "^17.0.38",
     "@types/react-dom": "^17.0.11",
-    "autoprefixer": "10.4.1",
+    "autoprefixer": "10.4.2",
     "copy-webpack-plugin": "10.2.0",
     "css-loader": "6.5.1",
     "css-minimizer-webpack-plugin": "^3.3.1",


### PR DESCRIPTION
Updates node-forge to 1.0.0 (dependabot wasn't able to do so because it was a "deep-link"), and catches two more dependency updates