### PR TITLE
Fully clear cloudfront cache on deploy

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -23,9 +23,6 @@ runs:
         aws s3 sync . "s3://${{ inputs.s3-bucket }}/" --exclude "static/*" --cache-control "max-age=60, public"
     - name: Invalidate CDN
       shell: bash
-      # this step isn't really necessary: all the files in the static directory with a long-lifetime cache
-      # are immutable so don't need clearing; and the index.html has a short lifetime of 60 seconds.
-      # but this might speed things up a bit.
       run: |
-        INVALIDATION_ID=$(aws cloudfront create-invalidation --distribution-id ${{ inputs.cloudfront-distribution-id }} --paths "/index.html" | jq -r '.Invalidation.Id')
+        INVALIDATION_ID=$(aws cloudfront create-invalidation --distribution-id ${{ inputs.cloudfront-distribution-id }} --paths "/*" | jq -r '.Invalidation.Id')
         aws cloudfront wait invalidation-completed --distribution-id ${{ inputs.cloudfront-distribution-id }} --id $INVALIDATION_ID


### PR DESCRIPTION
I'd tweaked this to just clear the index.html. However, CF does not appear to be clever enough to know that we serve that same file whenever a file is not found (so that direct links to rooms work), and it doesn't seem to respect the max-age 60 that we set on the source bucket.

As a result, direct room links are cached by cloudfront for long periods of time, meaning they run an old version of the code. This should resolve that.