### PR TITLE
Broken webpack link "https:://" => "https://"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Working with the code
 
-The website is built using [webpack 5](https:://webpack.js.org).
+The website is built using [webpack 5](https://webpack.js.org).
 
 To work with it locally:
 


### PR DESCRIPTION
Link redirected to a local github file that didnt exist, changed to official webpack website