### PR TITLE
Refresh home page every 5 min

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -101,14 +101,6 @@ const main = async () => {
   }
   populateRecordings(findElement("recordings"));
 
-  // every 5 minutes, if user is not in meeting then repopulate and render recordings
-  const interval = 5 * 60 * 1000;
-  setInterval(function () {
-    if (JitsiMeetJS == null) {
-      populateRecordings(findElement("recordings"));
-    }
-  }, interval);
-
   if (!joinRoom || joinRoom === "widget") {
     const context: Context = {
       browser,
@@ -439,8 +431,8 @@ const renderHomePage = (options: WelcomeScreenOptions) => {
     notice(options.showFailureMessage);
   }
 
-  // reload home page every 24 hours
-  const interval = 24 * 60 * 60 * 1000;
+  // reload home page every 5 min
+  const interval = 5 * 60 * 1000;
   setInterval(function () {
     if (JitsiMeetJS == null) {
       window.location.reload();


### PR DESCRIPTION
Instead of refreshing home page every 24 hours and the recordings list every 5 minutes (provided that a user is not in a meeting for both refreshes), we can instead refresh the home page every 5 minutes.