### PR TITLE
Added link to status page at footer

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -57,6 +57,12 @@
       content="AvOTJlgHvrjeQMMjZyMA6XRalMYRX4Cr5tBvel6Wu1vJSE0g6RxxhKldinn2K4kNUkH3eTXatwVe/mGIF9EL8wAAAAB6eyJvcmlnaW4iOiAiaHR0cHM6Ly90b2dldGhlci5icmF2ZS5jb206NDQzIiwgImlzU3ViZG9tYWluIjogdHJ1ZSwgImZlYXR1cmUiOiAiUlRDSW5zZXJ0YWJsZVN0cmVhbXMiLCAiZXhwaXJ5IjogMTc2Mzk0NTkzNn0="
     />
     -->
+    <script
+      src="https://betteruptime.com/widgets/announcement.js"
+      data-id="142720"
+      async="async"
+      type="text/javascript"
+    ></script>
 
     <script src="https://8x8.vc/libs/external_api.min.js"></script>
   </head>
@@ -178,7 +184,7 @@
               Your personal information always stays private, per our
               <a href="https://brave.com/privacy/browser/#brave-talk-learn"
                 >privacy policy</a
-              >.
+              >. <a href="https://status.brave.com/"> Service status</a>.
             </div>
           </div>
 

--- a/src/index.html
+++ b/src/index.html
@@ -57,12 +57,6 @@
       content="AvOTJlgHvrjeQMMjZyMA6XRalMYRX4Cr5tBvel6Wu1vJSE0g6RxxhKldinn2K4kNUkH3eTXatwVe/mGIF9EL8wAAAAB6eyJvcmlnaW4iOiAiaHR0cHM6Ly90b2dldGhlci5icmF2ZS5jb206NDQzIiwgImlzU3ViZG9tYWluIjogdHJ1ZSwgImZlYXR1cmUiOiAiUlRDSW5zZXJ0YWJsZVN0cmVhbXMiLCAiZXhwaXJ5IjogMTc2Mzk0NTkzNn0="
     />
     -->
-    <script
-      src="https://betteruptime.com/widgets/announcement.js"
-      data-id="142720"
-      async="async"
-      type="text/javascript"
-    ></script>
 
     <script src="https://8x8.vc/libs/external_api.min.js"></script>
   </head>

--- a/src/index.html
+++ b/src/index.html
@@ -178,7 +178,7 @@
               Your personal information always stays private, per our
               <a href="https://brave.com/privacy/browser/#brave-talk-learn"
                 >privacy policy</a
-              >. <a href="https://status.brave.com/"> Service status</a>.
+              >. <a href="https://status.brave.com/">Service status</a>.
             </div>
           </div>
 


### PR DESCRIPTION
c.f., https://github.com/brave/brave-talk/issues/14

After running into difficulty properly styling the BetterUptime announcement bar as well as security concerns from using a third party script, we decided to defer the status announcement bar and keep the link to the status page in the footer. 