### PR TITLE
small thing to declare string type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -303,7 +303,7 @@ const extractValueFromFragment = (key: string): string | undefined => {
   if (window.location.hash !== "") {
     const hashes = window.location.hash.substr(1).split("&");
 
-    hashes.forEach((hash) => {
+    hashes.forEach((hash: string) => {
       const equals = hash.indexOf("=");
 
       if (equals !== -1 && key === hash.substr(0, equals)) {


### PR DESCRIPTION
declare each hash value in `window.location.hash` as a `string`. i'm not sure why typescript occasionally complains (the array is generated by a string `.split`), but there's no harm in making it explicit.