### PR TITLE
use `audit-level=moderate` when running `npm audit`

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -16,7 +16,8 @@ runs:
         cache: npm
     - run: npm ci
       shell: bash
-    - run: npm audit
+    - name: npm audit
+      run: npm audit --audit-level=moderate
       shell: bash
     - run: npm test
       shell: bash


### PR DESCRIPTION
Looks good when examining the logs on github.