### PR TITLE
Force in-call display full screen

### DIFF
--- a/src/components/InCall.tsx
+++ b/src/components/InCall.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { IJistiMeetApi, renderConferencePage } from "../jitsi";
+import "../css/in-call.css";
 
 interface Props {
   roomName: string;
@@ -24,5 +25,5 @@ export const InCall: React.FC<Props> = (props) => {
     }
   }, [divRef, jistiMeet, props]);
 
-  return <div ref={divRef} css={{ height: "100%" }} />;
+  return <div ref={divRef} css={{ height: "100%" }} className="in-call" />;
 };

--- a/src/css/in-call.css
+++ b/src/css/in-call.css
@@ -1,0 +1,12 @@
+/*
+This is a temporary workaround to the issue with incorrect CSPs being returned,
+as described here: https://bravesoftware.slack.com/archives/C01BC0K5QP7/p1679915227867859
+*/
+
+.in-call {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  left: 0;
+}


### PR DESCRIPTION
Even if inline styles are not working.

See https://bravesoftware.slack.com/archives/C01BC0K5QP7/p1679915227867859: in some cases it appears the urls with room names in them are served with an old CSP that doesn't permit inline styles.

This is a temporary workaround so that the in-call UI still displays full screen even if inline styles are not permitted.