### PR TITLE
Safely load Jisti API asynchronously

### DIFF
--- a/src/components/InCall.tsx
+++ b/src/components/InCall.tsx
@@ -1,5 +1,9 @@
 import { useEffect, useRef, useState } from "react";
-import { IJistiMeetApi, renderConferencePage } from "../jitsi";
+import {
+  IJistiMeetApi,
+  renderConferencePage,
+  miniLoadedExternalApi,
+} from "../jitsi";
 
 interface Props {
   roomName: string;
@@ -13,6 +17,7 @@ export const InCall: React.FC<Props> = (props) => {
 
   useEffect(() => {
     if (!jistiMeet && divRef.current) {
+      miniLoadedExternalApi();
       setJitsiMeet(
         renderConferencePage(
           divRef.current,

--- a/src/components/InCall.tsx
+++ b/src/components/InCall.tsx
@@ -1,9 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import {
-  IJistiMeetApi,
-  renderConferencePage,
-  miniLoadedExternalApi,
-} from "../jitsi";
+import { IJistiMeetApi, renderConferencePage } from "../jitsi";
 
 interface Props {
   roomName: string;
@@ -17,15 +13,12 @@ export const InCall: React.FC<Props> = (props) => {
 
   useEffect(() => {
     if (!jistiMeet && divRef.current) {
-      miniLoadedExternalApi();
-      setJitsiMeet(
-        renderConferencePage(
-          divRef.current,
-          props.roomName,
-          props.jwt,
-          props.isMobile
-        )
-      );
+      renderConferencePage(
+        divRef.current,
+        props.roomName,
+        props.jwt,
+        props.isMobile
+      ).then(setJitsiMeet);
     }
   }, [divRef, jistiMeet, props]);
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,7 @@
 import { createRoot } from "react-dom/client";
 import { App } from "./App";
 import { env, isProduction, config } from "./environment";
+import { miniLoadExternalApi } from "./jitsi";
 
 import "./js/jwt-decode";
 
@@ -13,30 +14,15 @@ if (!isProduction) {
   document.title = env.toUpperCase() + " " + document.title;
 }
 
-// taken from https://github.com/jitsi/jitsi-meet-react-sdk/blob/main/src/init.ts#L4-L22
-// the goal is to load the bootstrap JS for the current JAAS release (we load JitsiMeetExternalAPI elsewhere)
-// so this function does exactly that and nothing else.
+const mountReactApp = async () => {
+  await miniLoadExternalApi("8x8.vc", "", config.vpaas);
 
-const miniLoadExternalApi = (
-  domain: string,
-  release?: string,
-  appId?: string
-) => {
-  const script: HTMLScriptElement = document.createElement("script");
-  const releaseParam: string = release ? `?release=${release}` : "";
-  const appIdPath: string = appId ? `${appId}/` : "";
+  const rootNode = document.getElementById("root");
 
-  script.async = false;
-  script.src = `https://${domain}/${appIdPath}external_api.js${releaseParam}`;
-  console.log(`!!! bootstrap ${script.src}`);
-  document.head.appendChild(script as Node);
+  if (rootNode) {
+    const root = createRoot(rootNode);
+    root.render(<App />);
+  }
 };
 
-miniLoadExternalApi("8x8.vc", "", config.vpaas);
-
-const rootNode = document.getElementById("root");
-
-if (rootNode) {
-  const root = createRoot(rootNode);
-  root.render(<App />);
-}
+mountReactApp();

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,7 +15,7 @@ if (!isProduction) {
 }
 
 const mountReactApp = async () => {
-  await miniLoadExternalApi("8x8.vc", "", config.vpaas);
+  miniLoadExternalApi("8x8.vc", "", config.vpaas);
 
   const rootNode = document.getElementById("root");
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,7 @@
 import { createRoot } from "react-dom/client";
 import { App } from "./App";
 import { env, isProduction, config } from "./environment";
-import { miniLoadExternalApi } from "./jitsi";
+import { startLoadingJitsiApi } from "./jitsi";
 
 import "./js/jwt-decode";
 
@@ -14,15 +14,14 @@ if (!isProduction) {
   document.title = env.toUpperCase() + " " + document.title;
 }
 
-const mountReactApp = async () => {
-  miniLoadExternalApi("8x8.vc", "", config.vpaas);
+// deliberately don't wait for the resolution of the promise
+// returned here - we'll await it only when we need to interact with
+// the jitsi api.
+void startLoadingJitsiApi("8x8.vc", "", config.vpaas);
 
-  const rootNode = document.getElementById("root");
+const rootNode = document.getElementById("root");
 
-  if (rootNode) {
-    const root = createRoot(rootNode);
-    root.render(<App />);
-  }
-};
-
-mountReactApp();
+if (rootNode) {
+  const root = createRoot(rootNode);
+  root.render(<App />);
+}

--- a/src/jitsi.ts
+++ b/src/jitsi.ts
@@ -364,3 +364,35 @@ export const renderConferencePage = (
 
   return JitsiMeetJS;
 };
+
+// taken from http://localhost:8080/Uw8dfAU56OYYzACPQ59_sU0WpQTWlC4sSQDQNeC7HOEhttps://github.com/jitsi/jitsi-meet-react-sdk/blob/main/src/init.ts#L4-L22
+// the goal is to load the bootstrap JS for the current JAAS release (we load JitsiMeetExternalAPI elsewhere)
+// so this function does exactly that and nothing else.
+
+declare let window: any;
+
+export const miniLoadExternalApi = (
+  domain: string,
+  release?: string,
+  appId?: string
+): Promise<IJistiMeetApi> =>
+  new Promise((resolve, reject) => {
+    if (window.JitsiMeetExternalApi) {
+      return resolve(window.JitsiMeetExternalApi);
+    }
+
+    const script: HTMLScriptElement = document.createElement("script");
+    const releaseParam: string = release ? `?release=${release}` : "";
+    const appIdPath: string = appId ? `${appId}/` : "";
+
+    script.async = false;
+    script.src = `https://${domain}/${appIdPath}external_api.js${releaseParam}`;
+    script.onload = () => {
+      console.log(`!!! bootstrap ${script.src}`);
+      resolve(window.JitsiMeetExternalApi);
+    };
+    script.onerror = () =>
+      reject(new Error(`Script load error: ${script.src}`));
+
+    document.head.appendChild(script as Node);
+  });

--- a/src/jitsi.ts
+++ b/src/jitsi.ts
@@ -8,15 +8,63 @@ import {
 
 export type IJistiMeetApi = any;
 
+// taken from https://github.com/jitsi/jitsi-meet-react-sdk/blob/main/src/init.ts#L4-L22
+// the goal is to load the bootstrap JS for the current JAAS release (we load JitsiMeetExternalAPI elsewhere)
+// so this function does exactly that and nothing else.
+
+declare let window: any;
+
+let loadingPromise: Promise<IJistiMeetApi>;
+
+export const startLoadingJitsiApi = (
+  domain: string,
+  release: string,
+  appId: string
+): Promise<IJistiMeetApi> => {
+  loadingPromise = new Promise((resolve, reject) => {
+    if (window.JitsiMeetExternalApi) {
+      return resolve(window.JitsiMeetExternalApi);
+    }
+
+    const script: HTMLScriptElement = document.createElement("script");
+    const releaseParam: string = release ? `?release=${release}` : "";
+    const appIdPath: string = appId ? `${appId}/` : "";
+
+    script.async = false;
+    script.src = `https://${domain}/${appIdPath}external_api.js${releaseParam}`;
+    script.onload = () => {
+      console.log(`!!! bootstrap ${script.src}`);
+      resolve(window.JitsiMeetExternalApi);
+    };
+    script.onerror = () =>
+      reject(new Error(`Script load error: ${script.src}`));
+
+    document.head.appendChild(script);
+  });
+
+  return loadingPromise;
+};
+
+const ensureJitsiApiLoaded = async () => {
+  if (!loadingPromise) {
+    throw Error(
+      "!!! you must call startLoadingJitsiApi before ensureJitsiApiLoaded"
+    );
+  }
+  await loadingPromise;
+};
+
 const disableBeforeUnloadHandlers = true;
 
-export const renderConferencePage = (
+export const renderConferencePage = async (
   el: Element,
   roomName: string,
   jwt: string,
   isMobile: boolean
-): IJistiMeetApi => {
+): Promise<IJistiMeetApi> => {
   reportMethod("renderConferencePage", { roomName, jwt });
+
+  await ensureJitsiApiLoaded();
 
   const options: any = {
     roomName: config.vpaas + "/" + roomName,
@@ -363,45 +411,4 @@ export const renderConferencePage = (
   }
 
   return JitsiMeetJS;
-};
-
-// taken from http://localhost:8080/Uw8dfAU56OYYzACPQ59_sU0WpQTWlC4sSQDQNeC7HOEhttps://github.com/jitsi/jitsi-meet-react-sdk/blob/main/src/init.ts#L4-L22
-// the goal is to load the bootstrap JS for the current JAAS release (we load JitsiMeetExternalAPI elsewhere)
-// so this function does exactly that and nothing else.
-
-declare let window: any;
-
-let loadingPromise: Promise<IJistiMeetApi>;
-
-export const miniLoadExternalApi = (
-  domain: string,
-  release?: string,
-  appId?: string
-): Promise<IJistiMeetApi> => {
-  loadingPromise = new Promise((resolve, reject) => {
-    if (window.JitsiMeetExternalApi) {
-      return resolve(window.JitsiMeetExternalApi);
-    }
-
-    const script: HTMLScriptElement = document.createElement("script");
-    const releaseParam: string = release ? `?release=${release}` : "";
-    const appIdPath: string = appId ? `${appId}/` : "";
-
-    script.async = false;
-    script.src = `https://${domain}/${appIdPath}external_api.js${releaseParam}`;
-    script.onload = () => {
-      console.log(`!!! bootstrap ${script.src}`);
-      resolve(window.JitsiMeetExternalApi);
-    };
-    script.onerror = () =>
-      reject(new Error(`Script load error: ${script.src}`));
-
-    document.head.appendChild(script as Node);
-  });
-
-  return loadingPromise;
-};
-
-export const miniLoadedExternalApi = async () => {
-  await loadingPromise;
 };

--- a/src/jitsi.ts
+++ b/src/jitsi.ts
@@ -371,12 +371,14 @@ export const renderConferencePage = (
 
 declare let window: any;
 
+let loadingPromise: Promise<IJistiMeetApi>;
+
 export const miniLoadExternalApi = (
   domain: string,
   release?: string,
   appId?: string
-): Promise<IJistiMeetApi> =>
-  new Promise((resolve, reject) => {
+): Promise<IJistiMeetApi> => {
+  loadingPromise = new Promise((resolve, reject) => {
     if (window.JitsiMeetExternalApi) {
       return resolve(window.JitsiMeetExternalApi);
     }
@@ -396,3 +398,10 @@ export const miniLoadExternalApi = (
 
     document.head.appendChild(script as Node);
   });
+
+  return loadingPromise;
+};
+
+export const miniLoadedExternalApi = async () => {
+  await loadingPromise;
+};


### PR DESCRIPTION
So we can more effectively pin versions, but also do this in a way that we ensure that the api has finished loading before we invoke it.