### PR TITLE
Use WakeLock API to keep screen on in calls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@emotion/react": "11.10.6",
+        "@types/dom-screen-wake-lock": "^1.0.1",
         "ethers": "6.3.0",
         "i18next": "22.4.15",
         "react": "18.2.0",
@@ -2951,6 +2952,11 @@
         "@types/express-serve-static-core": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/dom-screen-wake-lock": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/dom-screen-wake-lock/-/dom-screen-wake-lock-1.0.1.tgz",
+      "integrity": "sha512-WJQas3OFGcC8AeMzaa7FwzzbNNfanuV2R12kQYNp4BkUMghsRz5JxJ5RgVhJifhw7t0s6LvRSWZArmKbMDZ+5g=="
     },
     "node_modules/@types/eslint": {
       "version": "8.37.0",
@@ -15281,6 +15287,11 @@
         "@types/node": "*"
       }
     },
+    "@types/dom-screen-wake-lock": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/dom-screen-wake-lock/-/dom-screen-wake-lock-1.0.1.tgz",
+      "integrity": "sha512-WJQas3OFGcC8AeMzaa7FwzzbNNfanuV2R12kQYNp4BkUMghsRz5JxJ5RgVhJifhw7t0s6LvRSWZArmKbMDZ+5g=="
+    },
     "@types/eslint": {
       "version": "8.37.0",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.37.0.tgz",
@@ -22795,7 +22806,8 @@
       "dev": true
     },
     "yaml": {
-      "version": "https://registry.npmjs.org/yaml/-/yaml-2.2.2.tgz",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.2.tgz",
       "integrity": "sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA=="
     },
     "yargs": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   },
   "dependencies": {
     "@emotion/react": "11.10.6",
+    "@types/dom-screen-wake-lock": "^1.0.1",
     "ethers": "6.3.0",
     "i18next": "22.4.15",
     "react": "18.2.0",

--- a/src/components/InCall.tsx
+++ b/src/components/InCall.tsx
@@ -16,6 +16,7 @@ import {
   recordingStatusChangedHandler,
   subjectChangeHandler,
   videoQualityChangeHandler,
+  videoConferenceJoinedHandler,
 } from "../jitsi/event-handlers";
 
 interface Props {
@@ -54,6 +55,7 @@ export const InCall: React.FC<Props> = ({
         errorOccurredHandler,
         dataChannelOpenedHandler,
         endpointTextMessageReceivedHandler,
+        videoConferenceJoinedHandler,
       ];
 
       const options = jitsiOptions(roomName, divRef.current, jwt, isMobile);

--- a/src/jitsi/event-handlers.ts
+++ b/src/jitsi/event-handlers.ts
@@ -2,6 +2,7 @@ import { reportAction } from "../lib";
 import { ethers } from "ethers";
 import { IJitsiMeetApi, JitsiContext, JitsiOptions } from "./types";
 import { availableRecordings } from "../recordings-store";
+import { acquireWakeLock, releaseWakeLock } from "../wakelock";
 import {
   nowActive,
   updateRecTimestamp,
@@ -91,6 +92,7 @@ export const readyToCloseHandler = {
         clearTimeout(context.inactiveTimer);
       }
       jitsi.dispose();
+      releaseWakeLock();
       window.open(
         window.location.protocol + "//" + window.location.host,
         "_self",
@@ -248,4 +250,10 @@ export const dataChannelOpenedHandler = {
       })
     );
   },
+};
+
+// Prevent the screen from turning off while in the video conference
+export const videoConferenceJoinedHandler = {
+  name: "videoConferenceJoined",
+  fn: () => () => acquireWakeLock(),
 };

--- a/src/wakelock.ts
+++ b/src/wakelock.ts
@@ -1,0 +1,25 @@
+let wakelock: WakeLockSentinel | null = null;
+
+export const acquireWakeLock = async () => {
+  try {
+    wakelock = await navigator.wakeLock.request("screen");
+    console.log("!!! wakelock acquired", wakelock);
+  } catch (e: any) {
+    console.error(e);
+  }
+};
+
+export const releaseWakeLock = async () => {
+  if (wakelock !== null) {
+    await wakelock.release();
+    wakelock = null;
+  }
+};
+
+const tryReacquireWakeLock = async () => {
+  if (wakelock !== null && document.visibilityState === "visible") {
+    await acquireWakeLock();
+  }
+};
+
+document.addEventListener("visibilityChange", tryReacquireWakeLock);


### PR DESCRIPTION
This change makes use of the [WakeLock API](https://developer.mozilla.org/en-US/docs/Web/API/WakeLock) to keep the screen  on during calls.  Brave desktop supports this for sure, and I believe our Android build supports it as well (currently untested, however).  I do not know about support for iOS.

The purpose of this change is to keep the screen on during calls.  The design is such that the WakeLock API is utilized during the call only.  A wakelock is taken when the user joins the conference room, and is released when the user leaves.  If the user is on the main Brave Talk page, or on the join page, the wakelock will not be active and the screen will still lock.  But while they're in the conference room, the wakelock will ensure that, as long as the tab is visible, the screen will not lock.  If the tab is _not_ visible, the lock is automatically released.  When the tab is made visible again, the lock is re-acquired.

I believe this is sorely needed, especially on mobile.  My experience with Android in specific is that the screen will lock, disabling the speaker and microphone.  This requires continually interacting with the device, even if you're a passive participant in the conference, which is less than ideal.