### PR TITLE
Add web3 gating w/ query param

### DIFF
--- a/src/components/WelcomeScreen.tsx
+++ b/src/components/WelcomeScreen.tsx
@@ -43,6 +43,8 @@ export const WelcomeScreen: React.FC<Props> = ({
   setRoomName,
   setJitsiContext,
 }) => {
+  const query = new URLSearchParams(window.location.search);
+  const enableWeb3 = !!query.get("web3");
   const subscribed = useSubscribedStatus();
   const { t } = useTranslation();
   const onClickWeb3CTA = () => {
@@ -97,7 +99,12 @@ export const WelcomeScreen: React.FC<Props> = ({
           hideButtons={hasInitialRoomName}
         />
 
-        <Web3CTA onClick={onClickWeb3CTA} isSubscribed={subscribed === "yes"} />
+        {enableWeb3 && (
+          <Web3CTA
+            onClick={onClickWeb3CTA}
+            isSubscribed={subscribed === "yes"}
+          />
+        )}
 
         <Recordings />
 

--- a/utility/i18n-compare.js
+++ b/utility/i18n-compare.js
@@ -108,7 +108,7 @@ models.forEach((target) => {
   console.log("{" + (multipleP ? ` // ${target.lang}` : ""));
   Object.keys(baseline.model).forEach((key) => {
     const value = target.model[key] || `<<< ${baseline.model[key]}`;
-    console.log(`  "${key}": ${value}",`);
+    console.log(`  "${key}": "${value}",`);
   });
   console.log("}");
 });


### PR DESCRIPTION
Disables `Web3CTA` component unless query param `web3` is present with a value (e.g. `https://talk.brave.com/?web3=true`).  This just enables us to release this to production and test in that environment prior to making the feature openly available.