### PR TITLE
Fix Wallet Connect Timing Issue

### DIFF
--- a/src/components/web3/Login.tsx
+++ b/src/components/web3/Login.tsx
@@ -5,7 +5,7 @@ import { bodyText, walletAddress } from "./styles";
 
 interface Props {
   web3address?: string;
-  onAddressSelected: Dispatch<string>;
+  onAddressSelected: (address: string, event: string) => void;
 }
 
 export const Login: React.FC<Props> = ({ web3address, onAddressSelected }) => {
@@ -21,7 +21,7 @@ export const Login: React.FC<Props> = ({ web3address, onAddressSelected }) => {
       setNotice(<span>{t("wallet_connect_request")}</span>);
       web3Login()
         .then((address) => {
-          onAddressSelected(address);
+          onAddressSelected(address, "login");
           setNotice(undefined);
         })
         .catch((err) => {

--- a/src/components/web3/Login.tsx
+++ b/src/components/web3/Login.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { web3Login } from "./api";
 import { bodyText, walletAddress } from "./styles";

--- a/src/hooks/use-web3-call-state.ts
+++ b/src/hooks/use-web3-call-state.ts
@@ -17,7 +17,7 @@ interface Web3CallState {
   moderatorPoaps: POAP[];
   participantNFTCollections: NFTcollection[];
   moderatorNFTCollections: NFTcollection[];
-  setWeb3Address: (web3Address: string) => void;
+  setWeb3Address: (web3Address: string, event: string) => void;
   setPermissionType: (permissionType: string) => void;
   setNft: (nft: string) => void;
   setParticipantPoaps: (participanPoaps: POAP[]) => void;
@@ -37,7 +37,7 @@ interface Web3CallState {
 export function useWeb3CallState(
   setFeedbackMessage: (message: TranslationKeys) => void
 ): Web3CallState {
-  const [web3Address, setWeb3Address] = useState<string>();
+  const [web3Address, _setWeb3Address] = useState<string>();
   const [permissionType, setPermissionType] = useState<string>("POAP");
   const [nft, setNft] = useState<string | null>(null);
   const [participantPoaps, setParticipantPoaps] = useState<POAP[]>([]);
@@ -49,9 +49,29 @@ export function useWeb3CallState(
     NFTcollection[]
   >([]);
 
+  const setWeb3Address = (address: string, event: string) => {
+    _setWeb3Address((prevAddress) => {
+      switch (event) {
+        case "login": {
+          if (prevAddress) return prevAddress;
+          return address;
+          break;
+        }
+        case "accountsChanged": {
+          return address;
+          break;
+        }
+        default: {
+          return address;
+          break;
+        }
+      }
+    });
+  };
+
   window.ethereum?.on("accountsChanged", (accounts: string[]) => {
     console.log("!!! accountsChanged", accounts);
-    setWeb3Address(accounts[0]);
+    setWeb3Address(accounts[0], "accountsChanged");
   });
 
   const joinCall = async (
@@ -67,7 +87,7 @@ export function useWeb3CallState(
         avatarURL: nft,
       };
     } catch (e: any) {
-      console.error(e);
+      console.error(e.message);
 
       if (e.message.includes("user rejected action")) {
         setFeedbackMessage("sign_request_cancelled");
@@ -142,7 +162,7 @@ export function useWeb3CallState(
       window.history.pushState({}, "", "/" + roomName);
       return [roomName, jwt, auth];
     } catch (e: any) {
-      console.error(e);
+      console.error(e.message);
       if (e.message.includes("user rejected action")) {
         setFeedbackMessage("sign_request_cancelled");
       } else {

--- a/src/hooks/use-web3-call-state.ts
+++ b/src/hooks/use-web3-call-state.ts
@@ -55,15 +55,12 @@ export function useWeb3CallState(
         case "login": {
           if (prevAddress) return prevAddress;
           return address;
-          break;
         }
         case "accountsChanged": {
           return address;
-          break;
         }
         default: {
           return address;
-          break;
         }
       }
     });

--- a/src/jitsi/event-handlers.ts
+++ b/src/jitsi/event-handlers.ts
@@ -1,3 +1,4 @@
+import { isProduction } from "../environment";
 import { reportAction } from "../lib";
 import { ethers } from "ethers";
 import { IJitsiMeetApi, JitsiContext, JitsiOptions } from "./types";
@@ -174,6 +175,10 @@ export const endpointTextMessageReceivedHandler = {
   fn: (jitsi: IJitsiMeetApi, context: JitsiContext) => async (params: any) => {
     reportAction("endpointTextMessageReceived", params);
 
+    if (isProduction) {
+      return;
+    }
+
     if (!context.web3Participants) {
       return;
     }
@@ -229,6 +234,10 @@ export const dataChannelOpenedHandler = {
   name: "dataChannelOpened",
   fn: (jitsi: IJitsiMeetApi, context: JitsiContext) => (params: any) => {
     reportAction("dataChannelOpened", params);
+
+    if (isProduction) {
+      return;
+    }
 
     if (!context.web3Authentication) {
       return;


### PR DESCRIPTION
Resolves #908

To address the above issue, I've used a closure over the `set` method returned for the `web3Address` value when calling `useState` in `use-web3-call-state.ts`.  The closure takes the next value for `web3Address` and an event identifier, using an updater function in the call to the dispatch function (renamed `_setWeb3Address` from `setWeb3Address`), allowing inspection of the previous value of `web3Address` (the value presented to the updater function).

Because of the semantics of the above issue, if the event is `"login"`, and there's a previous value already set, we know that the previous value came from the `"accountsChanged"` event, which has the appropriate address.  In that case, we know that the address received by the `"accountsChanged"` event is correct and can discard the value passed to the closure.

In the case that the timing should happen in a different order (i.e. `"login"` event is seen before `"accountsChanged"`), the value provided by the `"login"` event will be used, and the previous value ignored.  And the value of subsequent `"accountsChanged"` events will have their values set, ignoring any previous values.

In testing, it seems that the value returned from `"accountsChanged"` is always the address the user selects.  And the value from `"login"`, which is only used when the `Login` component is rendered and there is no value for `web3Address`, can in the case that the wallet was never connected to the Talk website, return the wrong value.  In all other cases the `"login"` value is correct.  And in all other cases the `"accountsChanged"` event is not fired.  And in all cases the `"accountsChanged"` event seems to be correct.  So, in the case that the timing changes, we should still capture the correct value.

I've tested that  this holds true in the following scenarios:

1. Connecting the wallet to the Talk website for the first time, choosing an account other than the first (the original issue)
2. Connecting the wallet to the Talk website for the first time, choosing the first account
3. Starting a web3 call with a wallet that is already connected
4. Connecting a second account in the wallet to Brave Talk
5. Switching between accounts in the wallet.
6. Unlocking the wallet after the window has become inactive in the background.
7. Unlocking the wallet after having connected it to the Talk website.

The above are all tested on the view displayed after clicking the "Host a Web3 Call" button from the Brave Talk homepage.