### PR TITLE
Re-enable Text Selection

### DIFF
--- a/src/components/GlobalStyles.tsx
+++ b/src/components/GlobalStyles.tsx
@@ -3,7 +3,6 @@ import { css, Global } from "@emotion/react";
 export const GlobalStyles = () => (
   <Global
     styles={css({
-      "*": { userSelect: "none" },
       "*,*:before,*:after": { boxSizing: "inherit" },
       "input,textarea": {
         userSelect: "text",


### PR DESCRIPTION
Text selection was disabled  due to the inclusion of the following CSS:

```css
* {
  user-select: none;
}
```

This PR removes that rule.