### PR TITLE
Update NFT image handling

### DIFF
--- a/src/components/web3/OptionalSettings.tsx
+++ b/src/components/web3/OptionalSettings.tsx
@@ -48,9 +48,7 @@ export const OptionalSettings: React.FC<Props> = ({
   moderatorNFTCollections,
   setModeratorNFTCollections,
 }) => {
-  const nftItems = nfts
-    .map((n: NFT) => ({ ...n, imageUrl: n.image_url }))
-    .filter((i: { imageUrl: string }) => i.imageUrl);
+  const nftItems = nfts.map((n: NFT) => ({ ...n, imageUrl: n.image_url }));
   const selectedNftIdx = nfts.findIndex((n) => n.image_url === nft);
   const { t } = useTranslation();
 

--- a/src/components/web3/api.ts
+++ b/src/components/web3/api.ts
@@ -84,6 +84,7 @@ export const web3NFTs = async (address: string): Promise<NFT[]> => {
         collection: {
           collection_id: nft.collection?.collection_id,
           name: nft.collection?.name,
+          image_url: nft.collection?.image_url,
         },
       });
     });
@@ -127,7 +128,11 @@ export const web3NFTcollections = async (
           collections[nft.collection.collection_id] = {
             id: nft.collection.collection_id,
             name: nft.collection.name,
-            image_url: nft.image_url,
+            image_url: nft.previews?.image_small_url
+              ? nft.previews.image_small_url
+              : nft.image_url
+              ? nft.image_url
+              : nft.collection?.image_url,
           };
         }
 

--- a/src/components/web3/core.ts
+++ b/src/components/web3/core.ts
@@ -21,6 +21,10 @@ export interface NFT {
   collection?: {
     collection_id: string;
     name: string;
+    image_url: string;
+  };
+  previews?: {
+    image_small_url: string;
   };
 }
 


### PR DESCRIPTION
- Display the no NFT image for avatar NFTs instead of filtering them out
- Use previews image for nft collection images, falling back to nft image, collection image and no nft image, in that order.

Re #905 