### PR TITLE
Update App.tsx -- fix for fallback route option

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -106,7 +106,7 @@ export const App: React.FC = () => {
           />
         )}
         <Route
-          path="/"
+          path="*"
           element={
             <React.Fragment>
               <GlobalStyles />


### PR DESCRIPTION
A new dependency i.e., Route was added and did not have a fallback option. So initially it was designed just to look / or ?sol therefore when a user tries to join a call with /{room_name}, it was unable to see which route it should take but now it has default route * that automatically solves problem.
Fix for this issue: https://github.com/brave/brave-talk/issues/1131