### PR TITLE
Make ?sol=y the default

### DIFF
--- a/src/hooks/use-params.ts
+++ b/src/hooks/use-params.ts
@@ -1,16 +1,21 @@
 import { useState } from "react";
 
 interface Params {
-  // url has "create=y" meaning we've been invokved from the /talk slack extension
+  // url has "create=y" meaning we've been invoked from the /talk slack extension
   // in this case, we should only automatiucally create the room if the user is a subscriber
   isCreate: boolean;
 
-  // url has "create_only=y" meaning we should create the room but then immediately close the window
-  // rather than entering the room. This is used by the google calendar extension.
+  // url has "create_only=y" meaning we've been invoked by the calendar extension.
+  // in this case, we should create the room but then immediately close the window rather than entering the room
   isCreateOnly: boolean;
 
-  // url has "sol=y" meaning we should show option to start either solana or ethereum call
+  // url doesn't have "sol=n" meaning we should show option to allow Solana (or Ethereum)
   isSolana: boolean;
+
+  // url has "allow=y" meaning we should show option for allowing address
+  isAllowAddress: boolean;
+
+  // url has "debug=y" to allow things like seeing the NFT debugging page
   isDebug: boolean;
 }
 
@@ -22,7 +27,8 @@ export function useParams(): Params {
     return {
       isCreate: p.get("create") === "y",
       isCreateOnly: p.get("create_only") === "y",
-      isSolana: p.get("sol") === "y",
+      isSolana: p.get("sol") !== "n",
+      isAllowAddress: p.get("allow") === "y",
       isDebug: p.get("debug") === "y",
     };
   });


### PR DESCRIPTION
Change to make `?sol=y` as the default.  In a few weeks, we'll remove the query flag altogether.

In the comments in the file that parses the query parameters, I also fixed some typos and "improved" some explanations...