### PR TITLE
fix: correct prod location for labels-english

### DIFF
--- a/public/branding-config.json
+++ b/public/branding-config.json
@@ -29,6 +29,6 @@
     "#FFD43B"
   ],
   "labels": {
-    "en": "https://talk.brave.software/labels-english.json"
+    "en": "https://talk.brave.com/labels-english.json"
   }
 }


### PR DESCRIPTION
as noted by @kdenhartog, this file should be sourced from talk.brave.com