### PR TITLE
#1260 is probably failing due to missing the `npm audit fix` for postcss

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
       "devDependencies": {
         "@brave-intl/skus-sdk": "0.1.3",
         "@types/jest": "29.5.5",
-        "@types/react": "18.2.23",
+        "@types/react": "18.2.24",
         "@types/react-dom": "18.2.8",
         "@typescript-eslint/eslint-plugin": "6.7.3",
         "@typescript-eslint/parser": "6.7.3",
@@ -1647,9 +1647,9 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "18.2.23",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.23.tgz",
-      "integrity": "sha512-qHLW6n1q2+7KyBEYnrZpcsAmU/iiCh9WGCKgXvMxx89+TYdJWRjZohVIo9XTcoLhfX3+/hP0Pbulu3bCZQ9PSA==",
+      "version": "18.2.24",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.24.tgz",
+      "integrity": "sha512-Ee0Jt4sbJxMu1iDcetZEIKQr99J1Zfb6D4F3qfUWoR1JpInkY1Wdg4WwCyBjL257D0+jGqSl1twBjV8iCaC0Aw==",
       "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
@@ -8427,9 +8427,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.24",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.24.tgz",
-      "integrity": "sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==",
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
       "dev": true,
       "funding": [
         {
@@ -11657,7 +11657,7 @@
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
         "json5": "^2.2.2",
-        "semver": "7.5.4"
+        "semver": "^6.3.0"
       }
     },
     "@babel/generator": {
@@ -11682,7 +11682,7 @@
         "@babel/helper-validator-option": "^7.21.0",
         "browserslist": "^4.21.3",
         "lru-cache": "^5.1.1",
-        "semver": "7.5.4"
+        "semver": "^6.3.0"
       }
     },
     "@babel/helper-environment-visitor": {
@@ -12435,7 +12435,7 @@
             "@babel/parser": "^7.14.7",
             "@istanbuljs/schema": "^0.1.2",
             "istanbul-lib-coverage": "^3.2.0",
-            "semver": "7.5.4"
+            "semver": "^7.5.4"
           }
         }
       }
@@ -12890,9 +12890,9 @@
       "dev": true
     },
     "@types/react": {
-      "version": "18.2.23",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.23.tgz",
-      "integrity": "sha512-qHLW6n1q2+7KyBEYnrZpcsAmU/iiCh9WGCKgXvMxx89+TYdJWRjZohVIo9XTcoLhfX3+/hP0Pbulu3bCZQ9PSA==",
+      "version": "18.2.24",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.24.tgz",
+      "integrity": "sha512-Ee0Jt4sbJxMu1iDcetZEIKQr99J1Zfb6D4F3qfUWoR1JpInkY1Wdg4WwCyBjL257D0+jGqSl1twBjV8iCaC0Aw==",
       "dev": true,
       "requires": {
         "@types/prop-types": "*",
@@ -14164,7 +14164,7 @@
         "import-fresh": "^3.2.1",
         "parse-json": "^5.0.0",
         "path-type": "^4.0.0",
-        "yaml": "2.3.2"
+        "yaml": "2.2.2"
       }
     },
     "create-jest": {
@@ -16119,7 +16119,7 @@
         "@babel/parser": "^7.14.7",
         "@istanbuljs/schema": "^0.1.2",
         "istanbul-lib-coverage": "^3.2.0",
-        "semver": "7.5.4"
+        "semver": "^6.3.0"
       }
     },
     "istanbul-lib-report": {
@@ -17123,7 +17123,7 @@
       "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
       "dev": true,
       "requires": {
-        "semver": "7.5.4"
+        "semver": "^7.5.3"
       }
     },
     "make-error": {
@@ -17331,7 +17331,7 @@
       "requires": {
         "hosted-git-info": "^2.1.4",
         "resolve": "^1.10.0",
-        "semver": "7.5.4",
+        "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
       }
     },
@@ -17825,9 +17825,9 @@
       }
     },
     "postcss": {
-      "version": "8.4.24",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.24.tgz",
-      "integrity": "sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==",
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
       "dev": true,
       "requires": {
         "nanoid": "^3.3.6",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@brave-intl/skus-sdk": "0.1.3",
     "@types/jest": "29.5.5",
-    "@types/react": "18.2.23",
+    "@types/react": "18.2.24",
     "@types/react-dom": "18.2.8",
     "@typescript-eslint/eslint-plugin": "6.7.3",
     "@typescript-eslint/parser": "6.7.3",


### PR DESCRIPTION
This supercedes #1260 which is failing, presumably due to `npm audit` reporting that there's a moderate vulnerability in `postcss`

@tackley - i'm not sure why `npm install` downgraded `semver` (take a look at `package-lock.json` ... should i revert those changes?