### PR TITLE
Apply to production: #1383 and #1381

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11322,9 +11322,9 @@
       }
     },
     "node_modules/webpack-dev-middleware": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.3.tgz",
-      "integrity": "sha512-hj5CYrY0bZLB+eTO+x/j67Pkrquiy7kWepMHmUMoPsmcUaeEnQJqFzHJOyxgWlq746/wUuA64p9ta34Kyb01pA==",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.4.tgz",
+      "integrity": "sha512-BVdTqhhs+0IfoeAf7EoH5WE+exCmqGerHfDM0IL096Px60Tq2Mn9MAbnaGUe6HiMa41KMCYF19gyzZmBcq/o4Q==",
       "dev": true,
       "dependencies": {
         "colorette": "^2.0.10",
@@ -19978,9 +19978,9 @@
       }
     },
     "webpack-dev-middleware": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.3.tgz",
-      "integrity": "sha512-hj5CYrY0bZLB+eTO+x/j67Pkrquiy7kWepMHmUMoPsmcUaeEnQJqFzHJOyxgWlq746/wUuA64p9ta34Kyb01pA==",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.4.tgz",
+      "integrity": "sha512-BVdTqhhs+0IfoeAf7EoH5WE+exCmqGerHfDM0IL096Px60Tq2Mn9MAbnaGUe6HiMa41KMCYF19gyzZmBcq/o4Q==",
       "dev": true,
       "requires": {
         "colorette": "^2.0.10",

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -20,6 +20,7 @@ const styles = {
     fontSize: "16px",
     lineHeight: "20px",
     color: "#ffffff",
+    textDecoration: "none",
     "@media only screen and (max-width: 600px)": {
       width: "100%",
     },

--- a/src/components/SubscriptionCTA.tsx
+++ b/src/components/SubscriptionCTA.tsx
@@ -46,11 +46,12 @@ export const SubscriptionCTA = ({ subscribed }: Props) => {
       <Section>
         <h2 css={{ paddingTop: 34 }}>{t("premium_card_title")}</h2>
         <p css={{ marginBottom: 18 }}>{t("subscribe_text")}</p>
-        <Button hollow>
-          <a href={`${subsUrl}/plans/?intent=checkout&product=talk`}>
-            {t("welcome_page_button_hollow")}
-          </a>
-        </Button>
+        <a
+          href={`${subsUrl}/plans/?intent=checkout&product=talk`}
+          css={{ textDecoration: "none" }}
+        >
+          <Button hollow>{t("welcome_page_button_hollow")}</Button>
+        </a>
         <div css={{ marginTop: 16 }}>{t("subscribe_login_text")}</div>
         <div css={{ marginTop: 16 }}>
           {t("subscribe_login_premium")}{" "}


### PR DESCRIPTION
Looks good on desktop. Since `main` has Brave Talk Marvin in addition to these fixes, doing this PR to jump past Marvin PR.