### PR TITLE
Disable transcripts by default

### DIFF
--- a/src/jitsi/options.ts
+++ b/src/jitsi/options.ts
@@ -121,6 +121,9 @@ export const jitsiOptions = (
         "whiteboard",
       ],
       transcribingEnabled: true,
+      transcriptions: {
+        autoTranscribeOnRecord: false,
+      },
       useHostPageLocalStorage: true,
       videoQuality: {
         persist: true,

--- a/src/jitsi/options.ts
+++ b/src/jitsi/options.ts
@@ -121,7 +121,7 @@ export const jitsiOptions = (
         "whiteboard",
       ],
       transcribingEnabled: true,
-      transcriptions: {
+      transcription: {
         autoTranscribeOnRecord: false,
       },
       useHostPageLocalStorage: true,

--- a/src/jitsi/types.ts
+++ b/src/jitsi/types.ts
@@ -77,7 +77,7 @@ export type JitsiOptions = {
     };
     toolbarButtons: string[];
     transcribingEnabled: boolean;
-    transcriptions: {
+    transcription: {
       autoTranscribeOnRecord: boolean;
     };
     useHostPageLocalStorage: boolean;

--- a/src/jitsi/types.ts
+++ b/src/jitsi/types.ts
@@ -77,6 +77,9 @@ export type JitsiOptions = {
     };
     toolbarButtons: string[];
     transcribingEnabled: boolean;
+    transcriptions: {
+      autoTranscribeOnRecord: boolean;
+    };
     useHostPageLocalStorage: boolean;
     videoQuality: {
       persist: boolean;


### PR DESCRIPTION
Turn off both transcription and A/V recording options in the dialog... to require the user to decide what they want.