### PR TITLE
turn on disableThirdPartyRequests to avoid talking to non-JAAS servers

### DIFF
--- a/src/jitsi/options.ts
+++ b/src/jitsi/options.ts
@@ -40,10 +40,12 @@ export const jitsiOptions = (
       customToolbarButtons: <CustomToolbarButton[]>[],
       disabledSounds: ["E2EE_OFF_SOUND", "E2EE_ON_SOUND"],
       disableGTM: true,
-      doNotStoreRoom: true,
       disableBeforeUnloadHandlers: true,
       disableInviteFunctions: false,
+      // turn off all third-party requests, e.g., for avatars
+      disableThirdPartyRequests: true,
       disableTileEnlargement: true,
+      doNotStoreRoom: true,
       dropbox: {
         appKey: null,
       },


### PR DESCRIPTION
... avoid talking to non-JAAS servers.

The `disableThirdPartyRequests` option prevents loading of:

- Shared videos (youtube)
- GIFs
- Avatars
- Analytics
- any other new future features that use third-party requests

Thank you @bgrozev