### PR TITLE
Needed to upgrade @brave/leo to use latest @types/react

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "brave-talk-app",
       "version": "0.1.0",
       "dependencies": {
-        "@brave/leo": "github:brave/leo#8026f2eb134316da6d1f74a6b8a4cb5c3a046807",
+        "@brave/leo": "github:brave/leo#814c26dbbaa6a0ef4fc3fb9ff358cdd7333341c4",
         "@emotion/react": "11.13.3",
         "@types/dom-screen-wake-lock": "1.0.3",
         "buffer": "6.0.3",
@@ -22,7 +22,7 @@
       "devDependencies": {
         "@brave-intl/skus-sdk": "0.1.3",
         "@types/jest": "29.5.12",
-        "@types/react": "18.3.3",
+        "@types/react": "18.3.5",
         "@types/react-dom": "18.3.0",
         "@typescript-eslint/eslint-plugin": "6.21.0",
         "@typescript-eslint/parser": "6.21.0",
@@ -706,8 +706,8 @@
     },
     "node_modules/@brave/leo": {
       "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/brave/leo.git#8026f2eb134316da6d1f74a6b8a4cb5c3a046807",
-      "integrity": "sha512-BoVNL0Aufp7lP3BidwCqI8E4aPGlxpd0C7SK66V1l+iUuJnVQDKJZb+/j6SaR37shtTAX12TrmAtO8orUj7akQ==",
+      "resolved": "git+ssh://git@github.com/brave/leo.git#814c26dbbaa6a0ef4fc3fb9ff358cdd7333341c4",
+      "integrity": "sha512-S6Ifoba7xhJ8TTeho0VfwlSeGKFEtMztDXiHGCBBYGs5Ufarf5azXHLTxcZQlwH4ANx77RVkoZqp0at9PkhNMA==",
       "license": "MIT",
       "dependencies": {
         "@storybook/test": "8.1.11",
@@ -1996,9 +1996,9 @@
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
     },
     "node_modules/@types/react": {
-      "version": "18.3.3",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
-      "integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.5.tgz",
+      "integrity": "sha512-WeqMfGJLGuLCqHGYRGHxnKrXcTitc6L/nBUWfWPcTarG3t9PsquqUMuVeXZeca+mglY4Vo5GZjCi0A3Or2lnxA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13501,9 +13501,9 @@
       "dev": true
     },
     "@brave/leo": {
-      "version": "git+ssh://git@github.com/brave/leo.git#8026f2eb134316da6d1f74a6b8a4cb5c3a046807",
-      "integrity": "sha512-BoVNL0Aufp7lP3BidwCqI8E4aPGlxpd0C7SK66V1l+iUuJnVQDKJZb+/j6SaR37shtTAX12TrmAtO8orUj7akQ==",
-      "from": "@brave/leo@github:brave/leo#8026f2eb134316da6d1f74a6b8a4cb5c3a046807",
+      "version": "git+ssh://git@github.com/brave/leo.git#814c26dbbaa6a0ef4fc3fb9ff358cdd7333341c4",
+      "integrity": "sha512-S6Ifoba7xhJ8TTeho0VfwlSeGKFEtMztDXiHGCBBYGs5Ufarf5azXHLTxcZQlwH4ANx77RVkoZqp0at9PkhNMA==",
+      "from": "@brave/leo@github:brave/leo#814c26dbbaa6a0ef4fc3fb9ff358cdd7333341c4",
       "requires": {
         "@storybook/test": "8.1.11",
         "svelte": "4.2.19",
@@ -14532,9 +14532,9 @@
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
     },
     "@types/react": {
-      "version": "18.3.3",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
-      "integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.5.tgz",
+      "integrity": "sha512-WeqMfGJLGuLCqHGYRGHxnKrXcTitc6L/nBUWfWPcTarG3t9PsquqUMuVeXZeca+mglY4Vo5GZjCi0A3Or2lnxA==",
       "dev": true,
       "requires": {
         "@types/prop-types": "*",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@brave-intl/skus-sdk": "0.1.3",
     "@types/jest": "29.5.12",
-    "@types/react": "18.3.3",
+    "@types/react": "18.3.5",
     "@types/react-dom": "18.3.0",
     "@typescript-eslint/eslint-plugin": "6.21.0",
     "@typescript-eslint/parser": "6.21.0",
@@ -58,7 +58,7 @@
     "webpack-dev-server": "4.15.2"
   },
   "dependencies": {
-    "@brave/leo": "github:brave/leo#8026f2eb134316da6d1f74a6b8a4cb5c3a046807",
+    "@brave/leo": "github:brave/leo#814c26dbbaa6a0ef4fc3fb9ff358cdd7333341c4",
     "@emotion/react": "11.13.3",
     "@types/dom-screen-wake-lock": "1.0.3",
     "buffer": "6.0.3",


### PR DESCRIPTION
https://github.com/brave/brave-talk/actions/runs/10829439991/job/30047010581?pr=1487#step:3:83 shows the problem ... `@types/react` version `18.3.5` tighened up a type definition that caused an error on `npm run check`

@fallaciousreasoning updated `@brave/leo` and this branch incorporates both changes.

Looks good on desktop, `dev1`, `dev2`, and `dev3`.