### PR TITLE
Update options.ts

### DIFF
--- a/src/jitsi/options.ts
+++ b/src/jitsi/options.ts
@@ -43,7 +43,8 @@ export const jitsiOptions = (
       disableBeforeUnloadHandlers: true,
       disableInviteFunctions: false,
       // turn off all third-party requests, e.g., for avatars
-      disableThirdPartyRequests: true,
+      // not yet (waiting on iOS update)
+      //    disableThirdPartyRequests: true,
       disableTileEnlargement: true,
       doNotStoreRoom: true,
       dropbox: {


### PR DESCRIPTION
do not enable `disableThirdPartyRequests` until the Brave Browser for iOS is updated for a later SDK