### PR TITLE
PR 2527 with npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6799,10 +6799,11 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz",
-      "integrity": "sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.7.tgz",
+      "integrity": "sha512-fgVY8AV7qU7z/MmXJ/rxwbrtQH4jBQ9m7kp3llF0liB7glmFeVZFBepQb32T3y8n8k2+AEYuMPCpinYW+/CuRA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/http-proxy": "^1.17.8",
         "http-proxy": "^1.18.1",
@@ -18500,9 +18501,9 @@
       }
     },
     "http-proxy-middleware": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz",
-      "integrity": "sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.7.tgz",
+      "integrity": "sha512-fgVY8AV7qU7z/MmXJ/rxwbrtQH4jBQ9m7kp3llF0liB7glmFeVZFBepQb32T3y8n8k2+AEYuMPCpinYW+/CuRA==",
       "dev": true,
       "requires": {
         "@types/http-proxy": "^1.17.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "brave-talk-app",
       "version": "0.1.0",
       "dependencies": {
-        "@brave/leo": "github:brave/leo#481d25d74e33c8dd849e684220c6eb7b0a69ce2f",
+        "@brave/leo": "github:brave/leo#24fc7856282b10fd7e826e02db98ab56dd02fb2a",
         "@emotion/react": "11.13.3",
         "@types/dom-screen-wake-lock": "1.0.3",
         "buffer": "6.0.3",
@@ -706,8 +706,8 @@
     },
     "node_modules/@brave/leo": {
       "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/brave/leo.git#481d25d74e33c8dd849e684220c6eb7b0a69ce2f",
-      "integrity": "sha512-RSdCwvISYeAxHwk7/XiDYlvOPvh6T0fJRYFREiTerW20ktZ74ifKYvT2vCIiMDb9S3DCOVOr18bjZTc4AukUmQ==",
+      "resolved": "git+ssh://git@github.com/brave/leo.git#24fc7856282b10fd7e826e02db98ab56dd02fb2a",
+      "integrity": "sha512-5OEPu8eH3cDPFcIHtmK+ETfoVhxDOenD6imRPLjqcnHfuRPP45YE5ODmk/Tytg9Csj7+YCIa5OJ5IL+T282PkA==",
       "license": "MIT",
       "dependencies": {
         "@storybook/test": "8.3.5",
@@ -14104,9 +14104,9 @@
       "dev": true
     },
     "@brave/leo": {
-      "version": "git+ssh://git@github.com/brave/leo.git#481d25d74e33c8dd849e684220c6eb7b0a69ce2f",
-      "integrity": "sha512-RSdCwvISYeAxHwk7/XiDYlvOPvh6T0fJRYFREiTerW20ktZ74ifKYvT2vCIiMDb9S3DCOVOr18bjZTc4AukUmQ==",
-      "from": "@brave/leo@github:brave/leo#481d25d74e33c8dd849e684220c6eb7b0a69ce2f",
+      "version": "git+ssh://git@github.com/brave/leo.git#24fc7856282b10fd7e826e02db98ab56dd02fb2a",
+      "integrity": "sha512-5OEPu8eH3cDPFcIHtmK+ETfoVhxDOenD6imRPLjqcnHfuRPP45YE5ODmk/Tytg9Csj7+YCIa5OJ5IL+T282PkA==",
+      "from": "@brave/leo@github:brave/leo#24fc7856282b10fd7e826e02db98ab56dd02fb2a",
       "requires": {
         "@storybook/test": "8.3.5",
         "svelte": "4.2.19",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "webpack-dev-server": "5.1.0"
   },
   "dependencies": {
-    "@brave/leo": "github:brave/leo#481d25d74e33c8dd849e684220c6eb7b0a69ce2f",
+    "@brave/leo": "github:brave/leo#24fc7856282b10fd7e826e02db98ab56dd02fb2a",
     "@emotion/react": "11.13.3",
     "@types/dom-screen-wake-lock": "1.0.3",
     "buffer": "6.0.3",


### PR DESCRIPTION
https://github.com/brave/brave-talk/pull/1527 won't get approved because it lacks an `npm audit fix` and renovate hasn't updated it.