### PR TITLE
Enable the disableThirdPartyRequests option

### DIFF
--- a/src/jitsi/options.ts
+++ b/src/jitsi/options.ts
@@ -42,9 +42,7 @@ export const jitsiOptions = (
       disableGTM: true,
       disableBeforeUnloadHandlers: true,
       disableInviteFunctions: false,
-      // turn off all third-party requests, e.g., for avatars
-      // not yet (waiting on iOS update)
-      //    disableThirdPartyRequests: true,
+      disableThirdPartyRequests: true,
       disableTileEnlargement: true,
       doNotStoreRoom: true,
       dropbox: {


### PR DESCRIPTION
Briefly: this prevents the browser from talking to any services other than those at 8x8, e.g., the [auxilary services](https://developer.8x8.com/jaas/docs/technical-requirements-whitelists#auxiliary-functionality) and the [analytics](https://developer.8x8.com/jaas/docs/technical-requirements-whitelists#analytics) -- although analytics has been disabled since day one using a different configuration option.

Looks good on desktop, `dev1`, `dev2`, and `dev3`.