### PR TITLE
feat: Replace status.brave.com with status.brave.app

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -38,7 +38,7 @@ export const Footer = ({ browser }: Props) => {
           <a href="https://brave.com/privacy/browser/#brave-talk-learn">
             {t("footer_pst_text")}
           </a>
-          . <a href="https://status.brave.com/">{t("footer_status_text")}</a>.
+          . <a href="https://status.brave.app/">{t("footer_status_text")}</a>.
         </div>
       </Text>
     </div>


### PR DESCRIPTION
Preparation for upcoming `status.brave.com` -> `status.brave.app` domain change.

EDIT: Ready to be deployed - https://status.brave.app/ is now online.