### PR TITLE
chore: renovate config updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,21 +2,16 @@
   "extends": [
     "local>brave/renovate-config",
     "config:js-app",
-    ":semanticCommitsDisabled"
+    ":semanticCommitsDisabled",
+    "group:allNonMajor"
   ],
   "labels": ["dependencies"],
   "postUpdateOptions": ["npmDedupe"],
   "packageRules": [
     {
-      "matchDatasources": ["npm"],
-      "minimumReleaseAge": "4 days"
-    },
-    {
-      "groupName": "all non-major dependencies",
-      "groupSlug": "all-minor-patch",
-      "matchUpdateTypes": ["minor", "patch"],
-      "matchDatasources": ["npm"],
-      "matchPackageNames": ["*"]
+      "matchUpdateTypes": ["major"],
+      "enabled": true,
+      "dependencyDashboardApproval": true
     }
   ]
 }


### PR DESCRIPTION
To reduce noise, and also ensure we are aware of major version updates:

1. rely on org-global settings ([here](https://github.com/brave/renovate-config/blob/main/default.json)) for mininum release age, rather than overriding
2. group all non-major updates (not just for npm)
3. re-enable PRs for major version updates, but show these only in the dependency dashboard for now (https://github.com/brave/brave-talk/issues/1058) as there are quite a few of these