### PR TITLE
chore: Update community domain name

### DIFF
--- a/src/jitsi/options.ts
+++ b/src/jitsi/options.ts
@@ -187,7 +187,7 @@ export const jitsiOptions = (
       // remove 'dial-in'
       SHARING_FEATURES: ["email", "url", "embed"],
       SHOW_CHROME_EXTENSION_BANNER: false,
-      SUPPORT_URL: "https://community.brave.com/",
+      SUPPORT_URL: "https://community.brave.app/",
       TOOLBAR_BUTTONS: [
         "microphone",
         "camera",


### PR DESCRIPTION
For https://github.com/brave/devops/issues/13832

The redirect is included, so all the links will still work. Merge at your convenience.