### PR TITLE
Duplicate #1666 for main

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "brave-talk-app",
       "version": "0.1.0",
       "dependencies": {
-        "@brave/leo": "github:brave/leo#337971f2ed505f3a9c8f29ee15ef9d860bed5220",
+        "@brave/leo": "github:brave/leo#b0d5f184aee1862a37c3bd4dfe854fae5c784daa",
         "@emotion/react": "11.14.0",
         "@types/dom-screen-wake-lock": "1.0.3",
         "buffer": "6.0.3",
@@ -583,8 +583,8 @@
     },
     "node_modules/@brave/leo": {
       "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/brave/leo.git#337971f2ed505f3a9c8f29ee15ef9d860bed5220",
-      "integrity": "sha512-djuiPBuu7rCLjrDcM4xknQZW02VJY4vUOir4QWYaLsFD2PTaswg4pyEbumUtY80CIVEW3o0DFECxfREkezTJ+g==",
+      "resolved": "git+ssh://git@github.com/brave/leo.git#b0d5f184aee1862a37c3bd4dfe854fae5c784daa",
+      "integrity": "sha512-VSPQirHQ0TwR3tauxMrGx6/knUYCf5g0w444JMhdD1UGXLgYQEGphwlr+DOGDTe6eROEKk65k5aqFzOKpkxlaw==",
       "license": "MIT",
       "dependencies": {
         "@storybook/test": "8.6.14",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "webpack-dev-server": "5.2.2"
   },
   "dependencies": {
-    "@brave/leo": "github:brave/leo#337971f2ed505f3a9c8f29ee15ef9d860bed5220",
+    "@brave/leo": "github:brave/leo#b0d5f184aee1862a37c3bd4dfe854fae5c784daa",
     "@emotion/react": "11.14.0",
     "@types/dom-screen-wake-lock": "1.0.3",
     "buffer": "6.0.3",


### PR DESCRIPTION
The renovate `stability-days` timer keeps resetting and @fallaciousreasoning believes that this is safe to commit.

We use only a couple of icons from @brave/leo.

Since those buttons are used only for dowloads, and since only `dev2` has this working (recording is presently down on stage.8x8.vc, which is used by `dev1` and `dev3`): complete testing was done using `dev2` and it looks good.