### PR TITLE
chore(renovate): do not upgrade overrides

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>brave/renovate-config",
     "config:js-app",
@@ -6,12 +7,15 @@
     "group:allNonMajor"
   ],
   "labels": ["dependencies"],
-  "postUpdateOptions": ["npmDedupe"],
   "packageRules": [
     {
       "matchUpdateTypes": ["major"],
       "enabled": true,
       "dependencyDashboardApproval": true
+    },
+    {
+      "matchDepTypes": ["pnpm.overrides", "pnpm-workspace.overrides"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
The overrides setting in pnpm-workspace.yaml is used to specifically bump dependencies-of-dependencies to avoid vulnerabilities.

They should only be maintained by hand, by `pnpm audit --fix` or dependabot.  Arbitrarily upgrading or pinning deps-of-deps is a recipe for unexpected breakage, so tell renovate to leave it alone.

Also move renovate.json into the .github subdirectory, as is the usual pattern within Brave, and remove the npmdupe action now we've switched to pnpm.

This should fix https://github.com/brave/brave-talk/pull/1729, which breaks by arbitrarily and incorrectly updating the overrides.