### PR TITLE
Temporarily ignore registry errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "prepare": "husky",
     "check": "pnpm run /^check:.*/",
     "check:build": "tsc",
-    "check:audit": "pnpm audit",
+    "check:audit": "pnpm audit --ignore-registry-errors",
     "check:lint": "eslint src/",
     "check:format": "prettier --check ."
   },


### PR DESCRIPTION
Based on https://github.com/brave/ads-admin-dashboard/pull/2662

Apparently, one of the endpoints used by `pnpm audit` is no deprecated, resulting in sporadic errors. A new version of `pnpm` is in the works...

So, this is temporary until then.