### PR TITLE
chore(audit): upgrade fast-uri

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   brace-expansion@<1.1.13: ^1.1.13
   brace-expansion@>=4.0.0 <5.0.5: ^5.0.5
+  fast-uri@<=3.1.0: ^3.1.2
   flatted@<3.4.0: ^3.4.0
   follow-redirects@<=1.15.11: '>=1.16.0'
   handlebars@<=4.7.8: ^4.7.9
@@ -2256,8 +2257,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.0.6:
-    resolution: {integrity: sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fastest-levenshtein@1.0.16:
     resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
@@ -6200,7 +6201,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.0.6
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -7322,7 +7323,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.0.6: {}
+  fast-uri@3.1.2: {}
 
   fastest-levenshtein@1.0.16: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,6 +17,7 @@ auditConfig:
 overrides:
   brace-expansion@<1.1.13: '^1.1.13'
   brace-expansion@>=4.0.0 <5.0.5: '^5.0.5'
+  fast-uri@<=3.1.0: '^3.1.2'
   flatted@<3.4.0: "^3.4.0"
   follow-redirects@<=1.15.11: '>=1.16.0'
   handlebars@<=4.7.8: "^4.7.9"


### PR DESCRIPTION
(Manual execution of `pnpm audit --fix`, replacing the completely incorrect automated PR from dependabot - https://github.com/brave/brave-talk/pull/1755)

To address:

```
┌─────────────────────┬────────────────────────────────────────────────────────┐
│ high                │ fast-uri vulnerable to path traversal via              │
│                     │ percent-encoded dot segments                           │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Package             │ fast-uri                                               │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Vulnerable versions │ <=3.1.0                                                │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Patched versions    │ >=3.1.1                                                │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Paths               │ .>copy-webpack-plugin>schema-utils>ajv>fast-uri        │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ More info           │ https://github.com/advisories/GHSA-q3j6-qgpj-74h6      │
└─────────────────────┴────────────────────────────────────────────────────────┘
┌─────────────────────┬────────────────────────────────────────────────────────┐
│ high                │ fast-uri vulnerable to host confusion via              │
│                     │ percent-encoded authority delimiters                   │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Package             │ fast-uri                                               │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Vulnerable versions │ <=3.1.1                                                │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Patched versions    │ >=3.1.2                                                │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Paths               │ .>copy-webpack-plugin>schema-utils>ajv>fast-uri        │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ More info           │ https://github.com/advisories/GHSA-v39h-62p7-jpjc      │
└─────────────────────┴────────────────────────────────────────────────────────┘
6 vulnerabilities found
Severity: 4 moderate (4 ignored) | 2 high
```