### PR TITLE
Update renovate.json

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,6 +6,8 @@
     ":semanticCommitsDisabled",
     "group:allNonMajor"
   ],
+  "autoApprove": false,
+  "automerge": false,
   "labels": ["dependencies"],
   "packageRules": [
     {


### PR DESCRIPTION
disable `autoApprove` and `automerge`

Looks good on `dev1`, `dev2`, and `dev3` (not really testable but it doesn't break the build/deploy.

also, there isn't any explanation as to why the renovate folks aren't consistent in their capitalization.